### PR TITLE
fixed POI intent crashing app by adding a new floating action button with unique id

### DIFF
--- a/app/src/main/java/com/example/concordiaguide/PointOfInterest.java
+++ b/app/src/main/java/com/example/concordiaguide/PointOfInterest.java
@@ -18,7 +18,7 @@ public class PointOfInterest extends AppCompatActivity {
         Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 
-        FloatingActionButton fab = findViewById(R.id.fab);
+        FloatingActionButton fab = findViewById(R.id.fabPOI);
         fab.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {

--- a/app/src/main/res/layout/activity_poi.xml
+++ b/app/src/main/res/layout/activity_poi.xml
@@ -22,4 +22,12 @@
 
     <include layout="@layout/content_poi" />
 
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fabPOI"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="@dimen/fab_margin"
+        app:srcCompat="@android:drawable/ic_dialog_email" />
+
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
bugfix for #45 - crash was caused by the POI intent looking for the IndoorNavigation intent's action button id